### PR TITLE
Fix typo in race_hud.py

### DIFF
--- a/src/termtyper/ui/widgets/race_hud.py
+++ b/src/termtyper/ui/widgets/race_hud.py
@@ -106,7 +106,7 @@ class RaceHUD(Widget):
                     ),
                     Panel(
                         Text(
-                            "PM: {}    Accuracy: {}%    Progress: {}%".format(
+                            "WPM: {}    Accuracy: {}%    Progress: {}%".format(
                                 "{:.2f}".format(self.speed),
                                 "{:.2f}".format(self.accuracy),
                                 "{:.2f}".format(self.completed * 100),


### PR DESCRIPTION
Fixed a typo in race_hud.py. 

Changed "PM" to "WPM" (Words per minute)