### PR TITLE
Fix pip install error

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -28,6 +28,7 @@ jobs:
         pip install pyinstaller
     - name: Package app with pyinstaller
       run: |
+        python -c "with open('termtyper.py', 'w') as f: f.write('from termtyper import main\nmain()\n')"
         pyinstaller -F termtyper.py -i pic.ico
     - name: Upload a Build Artifact
       uses: actions/upload-artifact@v3.1.0
@@ -50,6 +51,7 @@ jobs:
         pip install pyinstaller
     - name: Package app with pyinstaller
       run: |
+        python -c "with open('termtyper.py', 'w') as f: f.write('from termtyper import main\nmain()\n')"
         pyinstaller -F termtyper.py -i pic.ico
     - name: Upload a Build Artifact
       uses: actions/upload-artifact@v3.1.0
@@ -72,6 +74,7 @@ jobs:
         pip install pyinstaller
     - name: Package app with pyinstaller
       run: |
+        python -c "with open('termtyper.py', 'w') as f: f.write('from termtyper import main\nmain()\n')"
         pyinstaller -F termtyper.py -i pic.ico
     - name: Upload a Build Artifact
       uses: actions/upload-artifact@v3.1.0

--- a/termtyper.py
+++ b/termtyper.py
@@ -1,3 +1,0 @@
-from termtyper import main
-
-main()


### PR DESCRIPTION
If we left some files outside `termtyper` dir, it will cause an error when using `pip install ...` command. 

I'm sorry that it was an oversight when I submitted #35 yesterday. 