### PR TITLE
Update Parser calls (Issue #41)

### DIFF
--- a/termtyper/ui/tui.py
+++ b/termtyper/ui/tui.py
@@ -18,12 +18,14 @@ from termtyper.ui.widgets.menus import BarThemeMenu, ModeMenu, SizeMenu, Timeout
 from ..ui.widgets import *  # NOQA
 from ..utils import *  # NOQA
 
+from ..utils.parser import MAIN_PARSER
+
 
 def percent(part, total):
     return int(part * total / 100)
 
 
-parser = Parser()
+parser = MAIN_PARSER
 
 
 class TermTyper(App):

--- a/termtyper/ui/widgets/number_scroll.py
+++ b/termtyper/ui/widgets/number_scroll.py
@@ -6,9 +6,9 @@ from textual.widget import Widget
 from rich.text import Text
 from rich.panel import Panel
 
-from ...utils import Parser
+from ...utils.parser import MAIN_PARSER
 
-parser = Parser()
+parser = MAIN_PARSER
 
 
 class NumberScroll(Widget):

--- a/termtyper/ui/widgets/option.py
+++ b/termtyper/ui/widgets/option.py
@@ -8,9 +8,9 @@ from rich.panel import Panel
 from textual import events
 from textual.widget import Widget
 
-from ...utils import Parser
+from ...utils.parser import MAIN_PARSER
 
-parser = Parser()
+parser = MAIN_PARSER
 SectionType = Literal[
     "user", "theming", "paragraph", "speed records word", "speed records time"
 ]
@@ -70,7 +70,7 @@ class Option(Widget):
 
     def update(self) -> None:
         if self.section:
-            Parser().set(self.section, self.name, self.options[self.cursor])
+            parser.set(self.section, self.name, self.options[self.cursor])
 
         if self.callback:
             self.callback()

--- a/termtyper/ui/widgets/race_hud.py
+++ b/termtyper/ui/widgets/race_hud.py
@@ -7,7 +7,9 @@ from textual.app import App
 from textual.widget import Widget
 
 from termtyper.ui.widgets.progress_bar import ProgressBar
-from ...utils import Parser
+from ...utils.parser import MAIN_PARSER
+
+parser = MAIN_PARSER
 
 
 class RaceHUD(Widget):
@@ -28,16 +30,16 @@ class RaceHUD(Widget):
         self.speed = 0
         self.finished = False
         self.details = False
-        self.theme = Parser().get_theme("bar_theme")
+        self.theme = parser.get_theme("bar_theme")
         self._read_speed_records()
 
     def toggle_details(self):
         self.details = not self.details
 
     def _read_speed_records(self) -> None:
-        self.low = Parser().get_speed("low")
-        self.med = Parser().get_speed("med")
-        self.high = Parser().get_speed("high")
+        self.low = parser.get_speed("low")
+        self.med = parser.get_speed("med")
+        self.high = parser.get_speed("high")
 
     def get_speed_color(self) -> str:
         """
@@ -89,7 +91,7 @@ class RaceHUD(Widget):
         Updates the HUD with the most current measurements
         """
 
-        self.mode = Parser().get("mode", "writing mode")
+        self.mode = parser.get("mode", "writing mode")
 
         if not self.finished:
             self.completed = progress
@@ -104,7 +106,7 @@ class RaceHUD(Widget):
             self.refresh()
 
     def refresh(self, repaint: bool = True, layout: bool = False) -> None:
-        self.theme = Parser().get_theme("bar_theme")
+        self.theme = parser.get_theme("bar_theme")
         return super().refresh(repaint, layout)
 
     def get_details(self) -> RenderableType:
@@ -113,7 +115,7 @@ class RaceHUD(Widget):
             param = "Progress"
             value = f"{self.completed * 100: 2.2f}%"
         else:
-            left = int(Parser().get_data("timeout"))
+            left = int(parser.get_data("timeout"))
             param = "Time left"
             value = str(int(left * self.completed))
 
@@ -138,7 +140,7 @@ class RaceHUD(Widget):
                             total=self.total,
                             completed=self.completed,
                             color="bold " + self.get_speed_color(),
-                            bar_style=Parser().get_theme("bar_theme"),
+                            bar_style=parser.get_theme("bar_theme"),
                         ).render()
                     ),
                     self.get_details() if self.details else "",

--- a/termtyper/ui/widgets/screen.py
+++ b/termtyper/ui/widgets/screen.py
@@ -11,14 +11,15 @@ from rich.panel import Panel
 from textual.app import App
 from textual.widget import Widget
 
-from ...utils import generate, Parser, play_keysound, play_failed
+from ...utils import generate, play_keysound, play_failed
+from ...utils.parser import MAIN_PARSER
 from ...events import UpdateRaceHUD, ResetHUD
 
 EMPTY_SPAN = Span(0, 0, "")
 x, y = get_terminal_size()
 HEIGHT = round(0.75 * y)
 WIDTH = round(0.80 * x)
-parser = Parser()
+parser = MAIN_PARSER
 
 
 class Screen(Widget):

--- a/termtyper/utils/parser.py
+++ b/termtyper/utils/parser.py
@@ -195,4 +195,5 @@ class Parser(ConfigParser):
     def get_data(self, data: str) -> str:
         return self.get("user", data)
 
+
 MAIN_PARSER = Parser()

--- a/termtyper/utils/parser.py
+++ b/termtyper/utils/parser.py
@@ -194,3 +194,5 @@ class Parser(ConfigParser):
 
     def get_data(self, data: str) -> str:
         return self.get("user", data)
+
+MAIN_PARSER = Parser()

--- a/termtyper/utils/play_keysound.py
+++ b/termtyper/utils/play_keysound.py
@@ -2,7 +2,7 @@ from threading import Thread
 from .preferredsoundplayer import playsound
 from os import path
 
-from ..utils import Parser
+from ..utils.parser import MAIN_PARSER
 
 SOUNDS_LOC = path.join(path.dirname(__file__), "..", "sounds")
 
@@ -16,7 +16,7 @@ def play(sound_file: str) -> None:
 
 
 def play_keysound() -> None:
-    sound = Parser().get_theme("sound")
+    sound = MAIN_PARSER.get_theme("sound")
     sound_file = get_sound_location(sound)
     play(sound_file)
 


### PR DESCRIPTION
Initialize `Parser` class only once to prevent other files from not being synchronized after a particular change to the config file. The config of all files will refer to `MAIN_PARSER` from `Parser.py`.

Fix Issue #41.