### PR TITLE
Fix version command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "termtyper"
-version = "2.0.0"
+version = "2.0.1"
 description = "A TUI based typing application"
 authors = ["kraanzu <kraanzu@gmail.com>"]
 license = "MIT"

--- a/termtyper/__init__.py
+++ b/termtyper/__init__.py
@@ -1,4 +1,4 @@
-import pkg_resources
+import importlib.metadata
 import argparse
 
 from .ui import TermTyper
@@ -22,7 +22,7 @@ def main():
     args = args.parse_args()
 
     if args.version:
-        ver = pkg_resources.get_distribution("dooit").version
+        ver = importlib.metadata.version("termtyper")
         print(f"termtyper - {ver}")
         return
 


### PR DESCRIPTION
The version command isn't working because it references another project.

This PR also removes the use of `pkg_resources` in favor of `importlib.metadata`, as recommended for newer python versions.